### PR TITLE
last user event

### DIFF
--- a/models/page_views/snowplow_last_user_page_view.sql
+++ b/models/page_views/snowplow_last_user_page_view.sql
@@ -1,0 +1,26 @@
+{{
+    config(
+        materialized = 'table',
+        sort='domain_userid',
+        dist='domain_userid',
+        unique_key='domain_userid'
+    )
+}}
+
+with prep as (
+    select 
+    collector_tstamp,
+    domain_userid,
+    page_view_id,
+    page_urlhost,
+    page_urlpath,
+    page_title,
+    br_family,
+    os_family,
+    dvce_type,
+    ROW_NUMBER() OVER (PARTITION BY domain_userid ORDER BY collector_tstamp DESC) as de_dupe
+    FROM {{ ref('snowplow_web_events') }}
+    GROUP BY 1,2,3,4,5,6,7,8,9
+)
+
+select * from prep where de_dupe = '1'

--- a/models/unstructured_event/snowplow_change_form.sql
+++ b/models/unstructured_event/snowplow_change_form.sql
@@ -1,0 +1,15 @@
+{{
+    config(
+        sort='event_id',
+        dist='event_id',
+        unique_key='event_id'
+    )
+}}
+
+with change_form as (
+
+    select * from {{ var('snowplow:change_form') }}
+
+)
+
+select * from change_form

--- a/models/unstructured_event/snowplow_last_unstructured_event.sql
+++ b/models/unstructured_event/snowplow_last_unstructured_event.sql
@@ -1,0 +1,62 @@
+{{
+    config(
+        materialized = 'table',
+        sort='domain_userid',
+        dist='domain_userid',
+        unique_key='domain_userid'
+    )
+}}
+
+with events as (
+    select * from {{ var('snowplow:events') }}
+),
+
+link_click as (
+    select * from {{ ref('snowplow_link_click') }}
+),
+
+submit_form as (
+    select * from {{ ref('snowplow_submit_form') }}
+),
+
+change_form as (
+    select * from {{ ref('snowplow_change_form') }}
+),
+
+
+prep as (
+    SELECT
+    ev.event,
+    ev.event_id,
+    ev.domain_userid,
+    ev.collector_tstamp,
+    lc.target_url as link_clicked_url,
+    sf.form_id as form_name,
+    cf.element_id as form_field_name,
+    CASE WHEN ROW_NUMBER() OVER (PARTITION BY ev.domain_userid ORDER BY ev.collector_tstamp DESC) = '1' AND EVENT = 'ue' THEN '1' ELSE '0' END as de_dupe
+    FROM events as ev
+    
+    LEFT JOIN link_click as lc
+    ON ev.event_id = lc.event_id
+    
+    LEFT JOIN submit_form as sf
+    ON ev.event_id = sf.event_id
+    
+    LEFT JOIN change_form as cf
+    ON ev.event_id = sf.event_id
+    
+    GROUP BY 1,2,3,4,5,6,7
+),
+
+de_dupe as (
+    SELECT 
+    domain_userid,
+    link_clicked_url,
+    form_name,
+    form_field_name
+    FROM prep
+    WHERE de_dupe = '1'
+)
+
+select * from de_dupe
+

--- a/models/unstructured_event/snowplow_link_click.sql
+++ b/models/unstructured_event/snowplow_link_click.sql
@@ -1,0 +1,15 @@
+{{
+    config(
+        sort='event_id',
+        dist='event_id',
+        unique_key='event_id'
+    )
+}}
+
+with link_click as (
+
+    select * from {{ var('snowplow:link_click') }}
+
+)
+
+select * from link_click

--- a/models/unstructured_event/snowplow_submit_form.sql
+++ b/models/unstructured_event/snowplow_submit_form.sql
@@ -1,0 +1,15 @@
+{{
+    config(
+        sort='event_id',
+        dist='event_id',
+        unique_key='event_id'
+    )
+}}
+
+with submit_form as (
+
+    select * from {{ var('snowplow:submit_form') }}
+
+)
+
+select * from submit_form

--- a/models/users/snowplow_users_last_event.sql
+++ b/models/users/snowplow_users_last_event.sql
@@ -1,0 +1,44 @@
+{{
+    config(
+        materialized = 'table',
+        sort='domain_userid',
+        dist='domain_userid',
+        unique_key='domain_userid'
+    )
+}}
+
+with uevent as (
+    select * from {{ ref('snowplow_last_unstructured_event')}}
+),
+
+prep as (
+    select * from {{ ref('snowplow_last_user_page_view')}}
+),
+
+final as (
+    SELECT 
+    d.domain_userid,
+    d.page_view_id,
+    d.page_urlhost,
+    d.page_urlpath,
+    d.page_title,
+    d.br_family,
+    d.os_family,
+    d.dvce_type
+    u.link_clicked_url,
+    u.form_name,
+    u.form_field_name,
+    CASE
+    WHEN u.domain_userid IS NOT NULL AND u.link_clicked_url IS NOT NULL THEN 'Link_Clicked'
+    WHEN u.domain_userid IS NOT NULL AND u.form_name IS NOT NULL THEN 'Submitted_Form'
+    WHEN u.domain_userid IS NOT NULL AND u.form_field_name IS NOT NULL THEN 'Filled_Form'
+    ELSE 'Page_Viewed' END AS last_user_event
+    FROM prep as d
+    
+    LEFT JOIN uevent as u
+    on d.domain_userid = u.domain_userid
+    
+    GROUP BY 1,2,3,4,5,6,7,8,9,10,11,12
+)
+
+select * from final 


### PR DESCRIPTION
## Description
added 6 models; (3 tables pulled directly from the source: submit_form, change_form, link_click and 3 tables created using custom sql)

## Motivation and Context
create a table to find the last pv event for each user, then the last ue attached to that pv

## How Has This Been Tested?
ran dbt data/schema tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.