### PR TITLE
Add pre/post hooks to user model

### DIFF
--- a/models/users/snowplow_users.sql
+++ b/models/users/snowplow_users.sql
@@ -101,17 +101,6 @@ prep as (
 
 ),
 
-incrementl_prep as (
-
-    select * from prep
-
-    {% if is_incremental() %}
-
-      where last_session_end > {{get_start_ts(this, 'last_session_end')}}
-
-    {% endif %}
-),
-
 users as (
 
     select
@@ -407,7 +396,7 @@ users as (
         GETDATE() AS updated
 
     from sessions as a
-        inner join incrementl_prep as b on a.inferred_user_id = b.inferred_user_id
+        inner join prep as b on a.inferred_user_id = b.inferred_user_id
         left join engagement as e on a.inferred_user_id = e.inferred_user_id
         left join lead as l on a.inferred_user_id = l.inferred_user_id
         left join viewcontent as v on a.inferred_user_id = v.inferred_user_id
@@ -421,6 +410,12 @@ users as (
         left join upsells as u on a.inferred_user_id = u.inferred_user_id
 
     where a.session_index = 1
+
+    {% if is_incremental() %}
+
+      and last_session_end > {{get_start_ts(this, 'last_session_end')}}
+
+    {% endif %}
 )
 
 select * from users where dedupe = 1

--- a/models/users/snowplow_users.sql
+++ b/models/users/snowplow_users.sql
@@ -96,6 +96,10 @@ prep as (
         max(viewport_width) as viewport_width
 
     from sessions
+    
+    {% if is_incremental() %}
+      where last_session_end > {{get_start_ts(this, 'last_session_end')}}
+    {% endif %}
 
     group by 1
 
@@ -410,12 +414,6 @@ users as (
         left join upsells as u on a.inferred_user_id = u.inferred_user_id
 
     where a.session_index = 1
-
-    {% if is_incremental() %}
-
-      and last_session_end > {{get_start_ts(this, 'last_session_end')}}
-
-    {% endif %}
 )
 
 select * from users where dedupe = 1


### PR DESCRIPTION
Create a table to be used as a lock, so other processes don't try an query the users model and break the active run